### PR TITLE
Update default tls version

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ module "redis" {
 | extra\_tags | Map of extra tags | `map(string)` | `{}` | no |
 | location | Azure region in which instance will be hosted | `string` | n/a | yes |
 | location\_short | Azure region trigram | `string` | n/a | yes |
-| minimum\_tls\_version | The minimum TLS version | `string` | `"1.0"` | no |
+| minimum\_tls\_version | The minimum TLS version | `string` | `"1.2"` | no |
 | name\_prefix | Optional prefix for the generated name | `string` | `""` | no |
 | private\_static\_ip\_address | The Static IP Address to assign to the Redis Cache when hosted inside the Virtual Network. Changing this forces a new resource to be created. | `string` | `null` | no |
 | redis\_additional\_configuration | Additional configuration for the Redis instance. Some of the keys are set automatically. See https://www.terraform.io/docs/providers/azurerm/r/redis_cache.html#redis_configuration for full reference. | `map(string)` | `{}` | no |

--- a/variables.tf
+++ b/variables.tf
@@ -84,7 +84,7 @@ variable "allow_non_ssl_connections" {
 variable "minimum_tls_version" {
   description = "The minimum TLS version"
   type        = string
-  default     = "1.0"
+  default     = "1.2"
 }
 
 variable "private_static_ip_address" {


### PR DESCRIPTION
Hello,

Azure will deprecrated TLS version under 1.2.
You will find informations on:
https://docs.microsoft.com/en-gb/azure/azure-cache-for-redis/cache-remove-tls-10-11

Thanks!