### PR TITLE
Add sensitive option to redis_configuration output that causes error

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -56,6 +56,7 @@ output "redis_capacity" {
 }
 
 output "redis_configuration" {
+  sensitive   = true
   value       = azurerm_redis_cache.redis.redis_configuration
   description = "Redis configuration"
 }


### PR DESCRIPTION
Using the module was causing an error and wasn't generate plan/output

```
│ Error: Output refers to sensitive values
│
│   on outputs.tf line 58:
│   58: output "redis_configuration" {
│
│ To reduce the risk of accidentally exporting sensitive data that was
│ intended to be only internal, Terraform requires that any root module
│ output containing sensitive data be explicitly marked as sensitive, to
│ confirm your intent.
│
│ If you do intend to export this data, annotate the output value as
│ sensitive by adding the following argument:
│     sensitive = true
╵
ERRO[0016] 1 error occurred:
	* exit status 1
```

Adding "sensitive" option to the `outputs.tf` file solved the issue. This issue is in latest version v5.0.0.

Tested Terraform version: v1.0.9